### PR TITLE
Fix duplicate entry in profile info config

### DIFF
--- a/tide_profile.info.yml
+++ b/tide_profile.info.yml
@@ -1,7 +1,6 @@
 name: Tide Profile
 type: module
 description: 'Provides Profile content type and related configuration. '
-type: module
 package: Tide
 core_version_requirement: ^8.9 || ^9
 dependencies:


### PR DESCRIPTION
When trying to build content-reference in a new environment (like DDEV, Gitpod et al) there is an error stemming from the syntax error in this modules info file:

```
Fetching bay.production DB dump
==> Searching for Drupal installation
==> Existing Drupal site found
==> Removing existing database tables

 // Do you really want to drop all tables in the database db?: yes.                                                     

==> Importing database
 [success] Cache rebuild complete.
The following operations will be performed:

 * Truncate sessions table.
 * Sanitize text fields associated with users.
 * Sanitize user emails.
 * Truncate webform submission tables.

 // Do you want to sanitize the current database?: yes.                                                                 

 [success] Sessions table truncated.
 [success] user__field_business_contact_number table sanitized.
 [success] user__field_business_name table sanitized.
 [success] No text fields for users need sanitizing.
 [success] user__field_notes table sanitized.
 [success] No text fields for users need sanitizing.
 [success] No text fields for users need sanitizing.
 [success] No text fields for users need sanitizing.
 [success] User emails sanitized.
 [notice] Webform submission tables truncated.
 [success] Cache rebuild complete.
==> Running database updates

In InfoParserDynamic.php line 53:
                                                                                                                                     
  Unable to parse modules/contrib/tide_profile/tide_profile.info.yml Duplicate key "type" detected at line 4 (near "type: module").  
                                                                                                                                     

Failed to execute command bash ./scripts/rebuild-env.sh: exit status 1
```

This prevents building in a new environment and is key to getting Gitpod or another type of remote build working.

Fixing this file manually in the checked out module allows us to proceed to having a working environment.